### PR TITLE
fix multi-monitor if some are disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Dependencies
 * imagemagick
 * bash
 * awk
+* jq
 * util-linux
 * grim
 

--- a/swaylock-fancy
+++ b/swaylock-fancy
@@ -17,7 +17,7 @@ declare -a outputs
 declare -a images
 
 # parse the json swaymsg for outputs
-poutputs=$(swaymsg -t get_outputs | grep name | sed 's/.*:.*\"\(.*\)\".*/\1/')
+poutputs=$(swaymsg -t get_outputs | jq -r '.[] | select(.active != false) | .name')
 while read -r line; do
     outputs+=($line)
     images+=($(mktemp --suffix=.png))


### PR DESCRIPTION
The script crashes with `unknown output 'eDP-1'` if a monitor is disabled.

This PR fixes that if you are willing to introduce a new dependency on `jq`.