### PR TITLE
Remove --nofork option and document swaylock options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,19 @@ Usage
                          Note: this option will not lock the screen, it displays
                          the list and exits immediately.
 
-        -n, --nofork     Do not fork swaylock after starting.
+
+    The following options are passed directly to swaylock:
+        -F, --show-failed-attempts    Show current count of failed authentication attempts.
+
+        -e, --ignore-empty-password   When an empty password is provided, do not validate it.
+
+        -K, --hide-keyboard-layout    Force hiding the current xkb layout while typing,
+                                      even if more than one layout is configured or the
+                                      show-keyboard-layout option is set.
+
+        -L, --disable-caps-lock-text  Disable the Caps Lock text.
+
+        --daemonize                   Detach from the controlling terminal after locking.
 
 example: ```swaylock-fancy -gpf Comic-Sans-MS -- scrot -z```
 

--- a/swaylock-fancy
+++ b/swaylock-fancy
@@ -103,7 +103,6 @@ while [[ $# > 0 ]] ; do
         -l|--listfonts)
 	    convert -list font | awk -F: '/Font: / { print $2 }' | sort -du | command -- ${PAGER:-less}
 	    exit 0 ;;
-	-n|--nofork) swaylock_cmd+=(--nofork) ; shift ;;
         -F|-e|-K|-L|--show-failed-attempts|--ignore-empty-password|--disable-caps-lock-text|--hide-keyboard-layout|--daemonize) swaylock_cmd+=("$1"); shift ;;
         --) shift; break ;;
         *) echo "unrecognized option: $1" ; exit 1 ;;


### PR DESCRIPTION
The documentation of options confused me when setting up `swayidle` with the `-w` (wait) option. Since I didn't pass the `--nofork` option I was expecting swaylock-fancy to fork to the background and not block swayidle from turning off the screen and eventually sleep.

Upon investigation I realised that `--nofork` is a relic from i3lock-fancy and not supported by swaylock, so I removed it and added extra doco to the readme for the extra options that are passed directly to the swaylock cmd.