### PR TITLE
Support any WM implementing the wlr-output-management protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Dependencies
 * jq
 * util-linux
 * grim
+* wlr-randr
 
 Optional Dependencies
 ---------------------

--- a/swaylock-fancy
+++ b/swaylock-fancy
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Author: Brandon Mittman <brandonmittman@gmail.com>
-# Dependencies: imagemagick, grim (optional)
+# Dependencies: imagemagick, wlr-randr, grim (optional)
 set -o errexit -o noclobber -o nounset
 
 PREFIX="${PREFIX:-$(pwd)}"
@@ -17,15 +17,7 @@ declare -a outputs
 declare -a images
 
 # parse wm client for display names
-if [[ "$XDG_CURRENT_DESKTOP" == "Hyprland" ]]; then
-    poutputs=$(hyprctl monitors -j | jq -rc '.[] | .name')
-elif [[ "$XDG_CURRENT_DESKTOP" == "niri" ]]; then
-    poutputs=$(niri msg -j outputs | jq -r '.[] | .name')
-elif [[ "$XDG_CURRENT_DESKTOP" == "labwc:wlroots" ]]; then
-    poutputs=$(wlr-randr --json | jq -r '.[] | select(.enabled == true) | .name')
-else
-    poutputs=$(swaymsg -t get_outputs | jq -r '.[] | select(.active != false) | .name')
-fi
+poutputs=$(wlr-randr --json | jq -r '.[] | select(.enabled == true) | .name')
 
 while read -r line; do
     outputs+=($line)

--- a/swaylock-fancy
+++ b/swaylock-fancy
@@ -21,6 +21,8 @@ if [[ "$XDG_CURRENT_DESKTOP" == "Hyprland" ]]; then
     poutputs=$(hyprctl monitors -j | jq -rc '.[] | .name')
 elif [[ "$XDG_CURRENT_DESKTOP" == "niri" ]]; then
     poutputs=$(niri msg -j outputs | jq -r '.[] | .name')
+elif [[ "$XDG_CURRENT_DESKTOP" == "labwc:wlroots" ]]; then
+    poutputs=$(wlr-randr --json | jq -r '.[] | select(.enabled == true) | .name')
 else
     poutputs=$(swaymsg -t get_outputs | jq -r '.[] | select(.active != false) | .name')
 fi


### PR DESCRIPTION
Tried to add support for labwc, but accidentally ended up writing a generic wlroots implementation.

Introduces wlr-randr as new dependency, but adds support for any WM that implements the wlr-output-management protocol.

This PR completely replaces all existing implementations, as I tested it on niri, Sway and Hyprland and it all works well.